### PR TITLE
test: Remove type annotation from `let _`

### DIFF
--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -1346,7 +1346,7 @@ fn decode_from_too_large_image() {
     let image = Cursor::new(image);
     let decoder = Decoder::new(image).unwrap();
     let mut buf = [u8::default(); 56];
-    let _: Result<(), Error> = decoder.decode(&mut buf);
+    let _ = decoder.decode(&mut buf);
 }
 
 #[test]
@@ -1380,7 +1380,7 @@ fn decode_with_invalid_buffer() {
         .unwrap();
     let decoder = Decoder::new(reader).unwrap();
     let mut buf = [];
-    let _: Result<(), Error> = decoder.decode(&mut buf);
+    let _ = decoder.decode(&mut buf);
 }
 
 #[cfg(feature = "image")]

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -7,7 +7,7 @@ use std::{
     str,
 };
 
-use xbm::{encode::Error, Encoder};
+use xbm::Encoder;
 
 #[test]
 fn encode() {
@@ -325,7 +325,7 @@ fn encode_with_invalid_dimensions() {
 
     let mut buf = [];
     let encoder = Encoder::new(buf.as_mut_slice());
-    let _: Result<(), Error> = encoder.encode(pixels, "image", 4, 3, None, None);
+    let _ = encoder.encode(pixels, "image", 4, 3, None, None);
 }
 
 #[cfg(feature = "image")]


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Because `clippy::let_underscore_untyped` was downgraded to `clippy::restriction`.

<!--
If it resolves an open issue, link to the issue here, otherwise remove this
line.
-->

Closes #

## Additional context

<!-- If you have any other context, describe them here. -->

## Checklist

- [ ] I have read the [Contribution Guide].
- [ ] I agree to follow the [Code of Conduct].

[Contribution Guide]: https://github.com/sorairolake/xbm-rs/blob/develop/CONTRIBUTING.adoc
[Code of Conduct]: https://github.com/sorairolake/xbm-rs/blob/develop/CODE_OF_CONDUCT.md
